### PR TITLE
extension: bootstrap skeleton and inject UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Turn StashDB from a simple database into a comprehensive content management syst
 ### Quick Install
 
 1. **Install browser extension:**
-
    - [Tampermonkey](https://www.tampermonkey.net/) (recommended)
    - [Violentmonkey](https://violentmonkey.github.io/) (alternative)
 
@@ -253,6 +252,28 @@ Interested in contributing or running your own build? See our [Development Guide
 - **Building from source**
 - **Contributing guidelines**
 - **Architecture overview**
+
+### Extension dev quickstart
+
+The browser extension lives in `extension/` and uses a dual-manifest approach:
+`manifest.chrome.json` (Chrome MV3) and `manifest.firefox.json` (Firefox MV3 with
+`browser_specific_settings`). The build script copies the right manifest into each output
+folder as `manifest.json`.
+
+```bash
+npm run build:extension
+```
+
+Outputs:
+
+- `dist/extension/chrome` → load with **Chrome** “Load unpacked”
+- `dist/extension/firefox` → load with **Firefox** `about:debugging` temporary add-on
+
+To rebuild during development:
+
+```bash
+npm run dev:extension
+```
 
 ### Tech Stack
 

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,0 +1,24 @@
+(() => {
+  const existing = document.getElementById('stasharr-extension-badge');
+  if (existing) {
+    return;
+  }
+
+  const badge = document.createElement('div');
+  badge.id = 'stasharr-extension-badge';
+  badge.textContent = 'Stasharr Extension Active';
+  badge.style.position = 'fixed';
+  badge.style.bottom = '16px';
+  badge.style.right = '16px';
+  badge.style.zIndex = '2147483647';
+  badge.style.padding = '8px 12px';
+  badge.style.borderRadius = '999px';
+  badge.style.background = 'rgba(17, 24, 39, 0.9)';
+  badge.style.color = '#fff';
+  badge.style.fontSize = '12px';
+  badge.style.fontFamily =
+    'system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif';
+  badge.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.2)';
+
+  document.body.appendChild(badge);
+})();

--- a/extension/manifest.chrome.json
+++ b/extension/manifest.chrome.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Stasharr Extension",
+  "version": "0.0.0",
+  "description": "Minimal Stasharr extension shell for StashDB.",
+  "content_scripts": [
+    {
+      "matches": ["https://stashdb.org/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Stasharr Extension",
+  "version": "0.0.0",
+  "description": "Minimal Stasharr extension shell for StashDB.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "stasharr-extension@example.com",
+      "strict_min_version": "109.0"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://stashdb.org/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "main": "stasharr.js",
   "scripts": {
     "build": "NODE_ENV=production webpack --config webpack.config.js --mode production",
+    "build:extension": "node scripts/build-extension.mjs",
+    "build:extension:chrome": "node scripts/build-extension.mjs --target=chrome",
+    "build:extension:firefox": "node scripts/build-extension.mjs --target=firefox",
     "prepare": "husky",
     "dev": "NODE_ENV=development webpack serve --config webpack.config.js",
+    "dev:extension": "node scripts/build-extension.mjs",
     "lint": "eslint . --fix",
     "preversion": "",
     "version": "npm run build",

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -1,0 +1,48 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const rootDir = process.cwd();
+const extensionDir = path.join(rootDir, 'extension');
+const outputDir = path.join(rootDir, 'dist', 'extension');
+
+const targets = new Map([
+  ['chrome', 'manifest.chrome.json'],
+  ['firefox', 'manifest.firefox.json'],
+]);
+
+const args = new Set(process.argv.slice(2));
+const requestedTargets = Array.from(targets.keys()).filter(
+  (target) => !args.size || args.has(`--target=${target}`) || args.has(target),
+);
+
+if (requestedTargets.length === 0) {
+  throw new Error(
+    'No valid targets provided. Use --target=chrome or --target=firefox.',
+  );
+}
+
+await fs.mkdir(outputDir, { recursive: true });
+
+const copyBuild = async (target) => {
+  const manifestName = targets.get(target);
+  const targetDir = path.join(outputDir, target);
+
+  await fs.rm(targetDir, { recursive: true, force: true });
+  await fs.mkdir(targetDir, { recursive: true });
+  await fs.copyFile(
+    path.join(extensionDir, manifestName),
+    path.join(targetDir, 'manifest.json'),
+  );
+  await fs.copyFile(
+    path.join(extensionDir, 'content-script.js'),
+    path.join(targetDir, 'content-script.js'),
+  );
+};
+
+await Promise.all(requestedTargets.map((target) => copyBuild(target)));
+
+const label =
+  requestedTargets.length === 1
+    ? requestedTargets[0]
+    : requestedTargets.join(', ');
+console.log(`Built extension targets: ${label}`);


### PR DESCRIPTION
### Motivation

- Provide a minimal cross-browser extension scaffold to prove content-script injection on `https://stashdb.org/*` pages. 
- Enable simple developer flows to iterate on a real extension artifact without changing the main userscript build.

### Description

- Added two MV3 manifests: `extension/manifest.chrome.json` for Chrome and `extension/manifest.firefox.json` for Firefox (using `browser_specific_settings`).
- Implemented a minimal content script `extension/content-script.js` that injects a small fixed badge to prove the script runs on StashDB pages.
- Added a build helper `scripts/build-extension.mjs` which copies the appropriate manifest and `content-script.js` into `dist/extension/<target>/manifest.json` and `content-script.js` for each target.
- Updated `package.json` with `build:extension`, `build:extension:chrome`, `build:extension:firefox`, and `dev:extension` npm scripts, and documented the quickstart in `README.md` under "Extension dev quickstart".

### Testing

- Ran `npm run build:extension`, which completed successfully and printed `Built extension targets: chrome, firefox`.
- Verified the build outputs exist under `dist/extension/chrome` and `dist/extension/firefox` and include `manifest.json` and `content-script.js` (inspected file contents during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981935bd1148333a83f775f8c7e77b2)