### PR TITLE
fix(performer): handle missing performer stash lookup

### DIFF
--- a/src/service/PerformerService.ts
+++ b/src/service/PerformerService.ts
@@ -23,6 +23,15 @@ export default class PerformerService extends ServiceBase {
     try {
       response = await ServiceBase.request(config, endpoint);
     } catch (error) {
+      // Whisparr returns 500 for missing performers on this endpoint.
+      // Treat this case as "not found" so normal add flows can continue.
+      if (
+        error instanceof Error &&
+        error.message.includes('HTML Response error: 500')
+      ) {
+        return null;
+      }
+
       ToastService.showToast(
         'Error occurred while looking up the performer',
         false,


### PR DESCRIPTION
Whisparr returns HTTP 500 when performer/{stashId} is not found.

Treat that response as null and skip error toast for normal add flow.

fix #187 